### PR TITLE
Placement groups, private IP address support

### DIFF
--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java
@@ -87,6 +87,8 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
             eTo.spotPrice(getSpotPrice());
          if (getSpotOptions() != null)
             eTo.spotOptions(getSpotOptions());
+         if (getPrivateIpAddress() != null)
+            eTo.privateIpAddress(getPrivateIpAddress());
       }
    }
 
@@ -99,6 +101,7 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    private Set<String> groupIds = ImmutableSet.of();
    private String iamInstanceProfileArn;
    private String iamInstanceProfileName;
+   private String privateIpAddress;
 
    @Override
    public boolean equals(Object o) {
@@ -112,13 +115,14 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
                && equal(this.noPlacementGroup, that.noPlacementGroup) && equal(this.subnetId, that.subnetId)
                && equal(this.spotPrice, that.spotPrice) && equal(this.spotOptions, that.spotOptions)
                && equal(this.groupIds, that.groupIds) && equal(this.iamInstanceProfileArn, that.iamInstanceProfileArn)
-               && equal(this.iamInstanceProfileName, that.iamInstanceProfileName);
+               && equal(this.iamInstanceProfileName, that.iamInstanceProfileName)
+               && equal(this.privateIpAddress, that.privateIpAddress);
    }
 
    @Override
    public int hashCode() {
       return Objects.hashCode(super.hashCode(), monitoringEnabled, placementGroup, noPlacementGroup, subnetId,
-               spotPrice, spotOptions, groupIds, iamInstanceProfileArn, iamInstanceProfileName);
+               spotPrice, spotOptions, groupIds, iamInstanceProfileArn, iamInstanceProfileName, privateIpAddress);
    }
 
    @Override
@@ -137,6 +141,7 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
          toString.add("groupIds", groupIds);
       toString.add("iamInstanceProfileArn", iamInstanceProfileArn);
       toString.add("iamInstanceProfileName", iamInstanceProfileName);
+      toString.add("privateIpAddress", privateIpAddress);
       return toString;
    }
 
@@ -194,6 +199,11 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    @SinceApiVersion("2012-06-01")
    public AWSEC2TemplateOptions iamInstanceProfileName(String name) {
       this.iamInstanceProfileName = checkNotNull(emptyToNull(name), "name must be defined");
+      return this;
+   }
+
+   public AWSEC2TemplateOptions privateIpAddress(String address) {
+      this.privateIpAddress = checkNotNull(emptyToNull(address), "address must be defined");
       return this;
    }
 
@@ -442,6 +452,11 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
       public static AWSEC2TemplateOptions iamInstanceProfileName(String name) {
          AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
          return options.iamInstanceProfileName(name);
+      }
+
+      public static AWSEC2TemplateOptions privateIpAddress(String address) {
+         AWSEC2TemplateOptions options = new AWSEC2TemplateOptions();
+         return options.privateIpAddress(address);
       }
 
       /**
@@ -789,5 +804,9 @@ public class AWSEC2TemplateOptions extends EC2TemplateOptions implements Cloneab
    @SinceApiVersion("2012-06-01")
    public String getIAMInstanceProfileName() {
       return iamInstanceProfileName;
+   }
+
+   public String getPrivateIpAddress() {
+      return privateIpAddress;
    }
 }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.ec2.compute.strategy;
 import static com.google.common.base.Predicates.and;
 import static com.google.common.base.Predicates.or;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.annotation.Resource;
@@ -27,6 +28,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import com.google.common.collect.ImmutableSet;
 import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
 import org.jclouds.aws.ec2.domain.RegionNameAndPublicKeyMaterial;
 import org.jclouds.aws.ec2.functions.CreatePlacementGroupIfNeeded;
@@ -64,6 +66,14 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions 
    @VisibleForTesting
    final Function<RegionNameAndPublicKeyMaterial, KeyPair> importExistingKeyPair;
 
+   final static Set<String> hardwareWithPlacementGroups = ImmutableSet.of(
+           "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge",
+           "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge",
+           "cc2.8xlarge", "cg1.4xlarge", "g2.2xlarge", "cr1.8xlarge",
+           "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge",
+           "hi1.4xlarge", "hs1.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge"
+   );
+
    @Inject
    public CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions(
          Function<RegionAndName, KeyPair> makeKeyPair, ConcurrentMap<RegionAndName, KeyPair> credentialsMap,
@@ -83,7 +93,7 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions 
       AWSRunInstancesOptions instanceOptions = AWSRunInstancesOptions.class
             .cast(super.execute(region, group, template));
 
-      String placementGroupName = template.getHardware().getId().startsWith("cc") ? createNewPlacementGroupUnlessUserSpecifiedOtherwise(
+      String placementGroupName = (hardwareWithPlacementGroups.contains(template.getHardware().getId())) ? createNewPlacementGroupUnlessUserSpecifiedOtherwise(
             region, group, template.getOptions()) : null;
 
       if (placementGroupName != null)

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/strategy/CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions.java
@@ -106,6 +106,8 @@ public class CreateKeyPairPlacementAndSecurityGroupsAsNeededAndReturnRunOptions 
          instanceOptions.withIAMInstanceProfileArn(awsTemplateOptions.getIAMInstanceProfileArn());
       if (awsTemplateOptions.getIAMInstanceProfileName() != null)
          instanceOptions.withIAMInstanceProfileName(awsTemplateOptions.getIAMInstanceProfileName());
+      if (awsTemplateOptions.getPrivateIpAddress() != null)
+         instanceOptions.withPrivateIpAddress(awsTemplateOptions.getPrivateIpAddress());
 
       return instanceOptions;
    }

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptions.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptions.java
@@ -115,6 +115,16 @@ public class AWSRunInstancesOptions extends RunInstancesOptions {
       return this;
    }
 
+   /**
+    * The primary IP address for VPC instance. You must specify a value from the IP address range of the subnet.
+    *
+    * @see org.jclouds.aws.ec2.domain.AWSRunningInstance#getPrivateIpAddress()
+    */
+   public AWSRunInstancesOptions withPrivateIpAddress(String address) {
+      formParameters.put("PrivateIpAddress", checkNotNull(address, "address"));
+      return this;
+   }
+
    public static class Builder extends RunInstancesOptions.Builder {
 
       /**
@@ -219,6 +229,14 @@ public class AWSRunInstancesOptions extends RunInstancesOptions {
       public static AWSRunInstancesOptions withBlockDeviceMappings(Set<? extends BlockDeviceMapping> mappings) {
          AWSRunInstancesOptions options = new AWSRunInstancesOptions();
          return options.withBlockDeviceMappings(mappings);
+      }
+
+      /**
+       * @see AWSRunInstancesOptions#withPrivateIpAddress(String)
+       */
+      public static AWSRunInstancesOptions withPrivateIpAdress(String address) {
+         AWSRunInstancesOptions options = new AWSRunInstancesOptions();
+         return options.withPrivateIpAddress(address);
       }
 
    }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/options/AWSEC2TemplateOptionsTest.java
@@ -16,17 +16,7 @@
  */
 package org.jclouds.aws.ec2.compute.options;
 
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.authorizePublicKey;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.blockOnPort;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.enableMonitoring;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.iamInstanceProfileArn;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.iamInstanceProfileName;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.inboundPorts;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.installPrivateKey;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.keyPair;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.noKeyPair;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.securityGroupIds;
-import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.securityGroups;
+import static org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions.Builder.*;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -414,5 +404,16 @@ public class AWSEC2TemplateOptionsTest {
    @Test(expectedExceptions = NullPointerException.class)
    public void testIAMInstanceProfileNameNPE() {
       iamInstanceProfileName(null);
+   }
+
+   @Test
+   public void testPrivateIpAddressStatic() {
+      AWSEC2TemplateOptions options = privateIpAddress("10.0.0.1");
+      assertEquals(options.getPrivateIpAddress(), "10.0.0.1");
+   }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testPrivateIpAddressNPE() {
+      privateIpAddress(null);
    }
 }

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/options/AWSRunInstancesOptionsTest.java
@@ -16,18 +16,7 @@
  */
 package org.jclouds.aws.ec2.options;
 
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.asType;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.enableMonitoring;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withBlockDeviceMappings;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withIAMInstanceProfileArn;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withIAMInstanceProfileName;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withKernelId;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withKeyName;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withRamdisk;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withSecurityGroup;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withSecurityGroupId;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withSubnetId;
-import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.withUserData;
+import static org.jclouds.aws.ec2.options.AWSRunInstancesOptions.Builder.*;
 import static org.testng.Assert.assertEquals;
 
 import org.jclouds.ec2.domain.BlockDeviceMapping;
@@ -371,6 +360,17 @@ public class AWSRunInstancesOptionsTest {
    @Test(expectedExceptions = NullPointerException.class)
    public void testWithBlockDeviceMappingNPE() {
       withBlockDeviceMappings(null);
+   }
+
+   @Test
+   public void testWithPrivateIpAddressStatic() {
+      AWSRunInstancesOptions options = withPrivateIpAdress("10.0.0.1");
+      assertEquals(options.buildFormParameters().get("PrivateIpAddress"), ImmutableList.of("10.0.0.1"));
+   }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testWithPrivateIpAddressStaticNPE() {
+      withPrivateIpAdress(null);
    }
 
 }


### PR DESCRIPTION
Removing this check at all may break backward compatibility, because `createNewPlacementGroupUnlessUserSpecifiedOtherwise` triggers some placementgroup-related sanity checks, that may not pass.
