### PR TITLE
JCE keys in LoginCredentials

### DIFF
--- a/core/src/main/java/org/jclouds/JcloudsVersion.java
+++ b/core/src/main/java/org/jclouds/JcloudsVersion.java
@@ -43,7 +43,7 @@ public class JcloudsVersion {
      * see http://semver.org.
      */
     private static final Pattern SEMANTIC_VERSION_PATTERN =
-        Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha|beta|rc)\\.(\\d+)|-SNAPSHOT)?");
+        Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha|beta|rc)\\.(\\d+)|-SNAPSHOT|-QUBELL.*)?");
     private static final String ALPHA_VERSION_IDENTIFIER = "alpha";
     private static final String BETA_VERSION_IDENTIFIER = "beta";
 

--- a/drivers/jsch/src/main/java/org/jclouds/ssh/jsch/SessionConnection.java
+++ b/drivers/jsch/src/main/java/org/jclouds/ssh/jsch/SessionConnection.java
@@ -174,6 +174,8 @@ public final class SessionConnection implements Connection<Session> {
       } else if (loginCredentials.hasUnencryptedPrivateKey()) {
          byte[] privateKey = loginCredentials.getPrivateKey().getBytes();
          jsch.addIdentity(loginCredentials.getUser(), privateKey, null, emptyPassPhrase);
+      } else if (loginCredentials.hasJceKeyPair()) {
+         throw new IllegalArgumentException("JCE keypairs are not supported by jclouds-jsch");
       } else if (agentConnector.isPresent()) {
          JSch.setConfig("PreferredAuthentications", "publickey");
          jsch.setIdentityRepository(new RemoteIdentityRepository(agentConnector.get()));

--- a/drivers/sshj/src/main/java/org/jclouds/sshj/SSHClientConnection.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/SSHClientConnection.java
@@ -28,6 +28,8 @@ import javax.inject.Named;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Buffer.BufferException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
+import net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
 import net.schmizz.sshj.userauth.method.AuthMethod;
 
@@ -162,6 +164,9 @@ public class SSHClientConnection implements Connection<SSHClient> {
       } else if (loginCredentials.hasUnencryptedPrivateKey()) {
          OpenSSHKeyFile key = new OpenSSHKeyFile();
          key.init(loginCredentials.getPrivateKey(), null);
+         ssh.authPublickey(loginCredentials.getUser(), key);
+      } else if (loginCredentials.hasJceKeyPair()) {
+         KeyProvider key = new KeyPairWrapper(loginCredentials.getKeyPair());
          ssh.authPublickey(loginCredentials.getUser(), key);
       } else if (agentConnector.isPresent()) {
          AgentProxy proxy = new AgentProxy(agentConnector.get());

--- a/drivers/sshj/src/main/java/org/jclouds/sshj/config/SshjSshClientModule.java
+++ b/drivers/sshj/src/main/java/org/jclouds/sshj/config/SshjSshClientModule.java
@@ -34,6 +34,8 @@ import com.google.inject.Scopes;
 import com.jcraft.jsch.agentproxy.AgentProxyException;
 import com.jcraft.jsch.agentproxy.Connector;
 import com.jcraft.jsch.agentproxy.ConnectorFactory;
+import net.schmizz.sshj.Config;
+import net.schmizz.sshj.DefaultConfig;
 
 /**
  * 
@@ -51,6 +53,9 @@ public class SshjSshClientModule extends AbstractModule {
       @Named(Constants.PROPERTY_CONNECTION_TIMEOUT)
       @Inject(optional = true)
       int timeout = 60000;
+
+      @Inject(optional = true)
+      Config config = new DefaultConfig();
 
       Optional<Connector> agentConnector = getAgentConnector();
 
@@ -73,7 +78,7 @@ public class SshjSshClientModule extends AbstractModule {
 
       @Override
       public SshClient create(HostAndPort socket, LoginCredentials credentials) {
-         SshClient client = new SshjSshClient(backoffLimitedRetryHandler, socket, credentials, timeout, getAgentConnector());
+         SshClient client = new SshjSshClient(backoffLimitedRetryHandler, socket, credentials, timeout, getAgentConnector(), config);
          injector.injectMembers(client);// add logger
          return client;
       }


### PR DESCRIPTION
Impact:
- ssh drivers
  Observable effects: 
- `LoginCredentials` now has method `keyPair(KeyPair keyPair)` (works only with sshj for now)
- it is possible to override default sshj config via guice module
- it is possible to provide `List<AuthMethodFactory>` via guice module

As the result, it is possible to use JCE keypairs, custom auth methods and custom signers with jclouds-sshj driver.
