### PR TITLE
Fixed deployment addresses and switched to non-snapshot versions

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>        
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-all</artifactId>

--- a/allblobstore/pom.xml
+++ b/allblobstore/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>        
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-allblobstore</artifactId>

--- a/allcompute/pom.xml
+++ b/allcompute/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>        
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-allcompute</artifactId>
@@ -53,6 +53,7 @@
       <artifactId>ec2</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>cloudservers-us</artifactId>
@@ -68,6 +69,7 @@
       <artifactId>cloudservers</artifactId>
       <version>${project.version}</version>
     </dependency>
+    -->
     <dependency>
       <groupId>org.apache.jclouds.api</groupId>
       <artifactId>vcloud</artifactId>

--- a/allloadbalancer/pom.xml
+++ b/allloadbalancer/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>        
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-allloadbalancer</artifactId>

--- a/apis/atmos/pom.xml
+++ b/apis/atmos/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
 

--- a/apis/byon/pom.xml
+++ b/apis/byon/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
 

--- a/apis/cloudfiles/pom.xml
+++ b/apis/cloudfiles/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/cloudstack/pom.xml
+++ b/apis/cloudstack/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/cloudwatch/pom.xml
+++ b/apis/cloudwatch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/ec2/pom.xml
+++ b/apis/ec2/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/elasticstack/pom.xml
+++ b/apis/elasticstack/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/filesystem/pom.xml
+++ b/apis/filesystem/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/openstack-cinder/pom.xml
+++ b/apis/openstack-cinder/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/openstack-nova-ec2/pom.xml
+++ b/apis/openstack-nova-ec2/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/openstack-trove/pom.xml
+++ b/apis/openstack-trove/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/rackspace-clouddns/pom.xml
+++ b/apis/rackspace-clouddns/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/rackspace-cloudidentity/pom.xml
+++ b/apis/rackspace-cloudidentity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/rackspace-cloudloadbalancers/pom.xml
+++ b/apis/rackspace-cloudloadbalancers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/route53/pom.xml
+++ b/apis/route53/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/s3/pom.xml
+++ b/apis/s3/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/sqs/pom.xml
+++ b/apis/sqs/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/sts/pom.xml
+++ b/apis/sts/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/swift/pom.xml
+++ b/apis/swift/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/apis/vcloud/pom.xml
+++ b/apis/vcloud/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>

--- a/blobstore/pom.xml
+++ b/blobstore/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-blobstore</artifactId>

--- a/common/azure/pom.xml
+++ b/common/azure/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.common</groupId>

--- a/common/openstack/pom.xml
+++ b/common/openstack/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.common</groupId>

--- a/compute/pom.xml
+++ b/compute/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-core</artifactId>

--- a/drivers/apachehc/pom.xml
+++ b/drivers/apachehc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/bouncycastle/pom.xml
+++ b/drivers/bouncycastle/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/enterprise/pom.xml
+++ b/drivers/enterprise/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/gae/pom.xml
+++ b/drivers/gae/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/joda/pom.xml
+++ b/drivers/joda/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/jsch/pom.xml
+++ b/drivers/jsch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/log4j/pom.xml
+++ b/drivers/log4j/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/netty/pom.xml
+++ b/drivers/netty/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/okhttp/pom.xml
+++ b/drivers/okhttp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/pom.xml
+++ b/drivers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-drivers-project</artifactId>

--- a/drivers/slf4j/pom.xml
+++ b/drivers/slf4j/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/drivers/sshj/pom.xml
+++ b/drivers/sshj/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.driver</groupId>

--- a/loadbalancer/pom.xml
+++ b/loadbalancer/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-loadbalancer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>        
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds</artifactId>
@@ -47,10 +47,15 @@
     <module>all</module>
   </modules>
     <distributionManagement>
+    <repository>
+        <id>aws-release</id>
+        <name>AWS S3 Release Repository</name>
+        <url>s3://cometera-mvn-repo/releases</url>
+    </repository>
     <snapshotRepository>
       <id>aws-snapshot</id>
       <name>AWS Snapshot Repository</name>
-      <url>s3://cometera-mvn-repo/snapshot</url>
+      <url>s3://cometera-mvn-repo/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
   <build>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>org.apache.jclouds</groupId>
   <artifactId>jclouds-project</artifactId>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.4-QUBELL-2015.12.16</version>
   <packaging>pom</packaging>
   <name>Apache jclouds Project</name>
   <url>http://jclouds.apache.org/</url>
@@ -96,7 +96,7 @@
     <repository>
         <id>aws-release</id>
         <name>AWS S3 Release Repository</name>
-        <url>s3://cometera-mvn-repo/release</url>
+        <url>s3://cometera-mvn-repo/releases</url>
     </repository>
 
     <snapshotRepository>

--- a/providers/aws-cloudwatch/pom.xml
+++ b/providers/aws-cloudwatch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/aws-ec2/pom.xml
+++ b/providers/aws-ec2/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/aws-route53/pom.xml
+++ b/providers/aws-route53/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/aws-s3/pom.xml
+++ b/providers/aws-s3/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/aws-sqs/pom.xml
+++ b/providers/aws-sqs/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/aws-sts/pom.xml
+++ b/providers/aws-sts/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/azureblob/pom.xml
+++ b/providers/azureblob/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/cloudfiles-uk/pom.xml
+++ b/providers/cloudfiles-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/cloudfiles-us/pom.xml
+++ b/providers/cloudfiles-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/dynect/pom.xml
+++ b/providers/dynect/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-ams-e/pom.xml
+++ b/providers/elastichosts-ams-e/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-hkg-e/pom.xml
+++ b/providers/elastichosts-hkg-e/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-lax-p/pom.xml
+++ b/providers/elastichosts-lax-p/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-lon-b/pom.xml
+++ b/providers/elastichosts-lon-b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-lon-p/pom.xml
+++ b/providers/elastichosts-lon-p/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-sat-p/pom.xml
+++ b/providers/elastichosts-sat-p/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-sjc-c/pom.xml
+++ b/providers/elastichosts-sjc-c/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-syd-v/pom.xml
+++ b/providers/elastichosts-syd-v/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/elastichosts-tor-p/pom.xml
+++ b/providers/elastichosts-tor-p/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/glesys/pom.xml
+++ b/providers/glesys/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/go2cloud-jhb1/pom.xml
+++ b/providers/go2cloud-jhb1/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/gogrid/pom.xml
+++ b/providers/gogrid/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/hpcloud-blockstorage/pom.xml
+++ b/providers/hpcloud-blockstorage/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/hpcloud-compute/pom.xml
+++ b/providers/hpcloud-compute/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/hpcloud-objectstorage/pom.xml
+++ b/providers/hpcloud-objectstorage/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/openhosting-east1/pom.xml
+++ b/providers/openhosting-east1/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudblockstorage-uk/pom.xml
+++ b/providers/rackspace-cloudblockstorage-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudblockstorage-us/pom.xml
+++ b/providers/rackspace-cloudblockstorage-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-clouddatabases-uk/pom.xml
+++ b/providers/rackspace-clouddatabases-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-clouddatabases-us/pom.xml
+++ b/providers/rackspace-clouddatabases-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-clouddns-uk/pom.xml
+++ b/providers/rackspace-clouddns-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-clouddns-us/pom.xml
+++ b/providers/rackspace-clouddns-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudloadbalancers-uk/pom.xml
+++ b/providers/rackspace-cloudloadbalancers-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudloadbalancers-us/pom.xml
+++ b/providers/rackspace-cloudloadbalancers-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudservers-uk/pom.xml
+++ b/providers/rackspace-cloudservers-uk/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/rackspace-cloudservers-us/pom.xml
+++ b/providers/rackspace-cloudservers-us/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/serverlove-z1-man/pom.xml
+++ b/providers/serverlove-z1-man/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/skalicloud-sdg-my/pom.xml
+++ b/providers/skalicloud-sdg-my/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/softlayer/pom.xml
+++ b/providers/softlayer/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/providers/ultradns-ws/pom.xml
+++ b/providers/ultradns-ws/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.provider</groupId>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>    
   <artifactId>jclouds-resources</artifactId>

--- a/scriptbuilder/pom.xml
+++ b/scriptbuilder/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <artifactId>jclouds-scriptbuilder</artifactId>

--- a/skeletons/pom.xml
+++ b/skeletons/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>jclouds-project</artifactId>
     <groupId>org.apache.jclouds</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../project/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/skeletons/standalone-compute/pom.xml
+++ b/skeletons/standalone-compute/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.jclouds</groupId>
     <artifactId>jclouds-project</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.4-QUBELL-2015.12.16</version>
     <relativePath>../../project/pom.xml</relativePath>
   </parent>
   <groupId>org.apache.jclouds.api</groupId>


### PR DESCRIPTION
As a side effect, I also commented `cloudservers-*` dependencies in allcompute/pom.xml out because they interfere with the build process (it seems these are artifacts from somewhere else) in order to allow the build to pass at all. This does not seem to affect anything, because allcompute seems to be just an aggregator for development purposes.

Also fixed incorrect repository name on S3 in the deployment settings.
